### PR TITLE
Extend and refine the IGH read collection scripts

### DIFF
--- a/IGLoo/scripts/collect_IGH_from_CHM13.sh
+++ b/IGLoo/scripts/collect_IGH_from_CHM13.sh
@@ -1,23 +1,18 @@
-# usage: bash fetch_IGH_from_grch38.sh sample_ID input_bam output_path
+# usage: bash fetch_IGH_from_chm13.sh sample_ID input_bam output_path
 
-IGH_locus="chr14:105486937-106979845"
-IGH_alt_locus="chr14_KI270726v1_random:0-43739"
+IGH_locus="chr14:99739969-101161492"
 sample_ID=$1
 input_bam=$2
 output_path=$3
 
 mkdir -p ${output_path}
 samtools view -h ${input_bam} ${IGH_locus}     -o ${output_path}/${sample_ID}.IGH_chr14.bam
-samtools view -h ${input_bam} ${IGH_alt_locus} -o ${output_path}/${sample_ID}.IGH_alt.bam
 samtools view -h ${input_bam} '*'              -o ${output_path}/${sample_ID}.unmapped.bam
 
 cd ${output_path}
 samtools merge ${sample_ID}.IGH.bam \
                ${sample_ID}.IGH_chr14.bam \
-               ${sample_ID}.IGH_alt.bam \
                ${sample_ID}.unmapped.bam
 samtools fastq ${sample_ID}.IGH.bam      >  ${sample_ID}.IGH.fq
-samtools fastq ${sample_ID}.IGH_alt.bam  >> ${sample_ID}.IGH.fq
-samtools fastq ${sample_ID}.unmapped.bam >> ${sample_ID}.IGH.fq
 
 cd -

--- a/IGLoo/scripts/collect_IGH_from_chm13.sh
+++ b/IGLoo/scripts/collect_IGH_from_chm13.sh
@@ -1,4 +1,4 @@
-# usage: bash fetch_IGH_from_chm13.sh sample_ID input_bam output_path
+# usage: bash collect_IGH_from_chm13.sh sample_ID input_bam output_path
 
 IGH_locus="chr14:99739969-101161492"
 sample_ID=$1

--- a/IGLoo/scripts/collect_IGH_from_grch38.sh
+++ b/IGLoo/scripts/collect_IGH_from_grch38.sh
@@ -1,4 +1,4 @@
-# usage: bash fetch_IGH_from_grch38.sh sample_ID input_bam output_path
+# usage: bash collect_IGH_from_grch38.sh sample_ID input_bam output_path
 
 IGH_locus="chr14:105486937-106979845"
 IGH_alt_locus="chr14_KI270726v1_random:0-43739"

--- a/IGLoo/scripts/collect_IGH_from_grch38.sh
+++ b/IGLoo/scripts/collect_IGH_from_grch38.sh
@@ -17,7 +17,5 @@ samtools merge ${sample_ID}.IGH.bam \
                ${sample_ID}.IGH_alt.bam \
                ${sample_ID}.unmapped.bam
 samtools fastq ${sample_ID}.IGH.bam      >  ${sample_ID}.IGH.fq
-samtools fastq ${sample_ID}.IGH_alt.bam  >> ${sample_ID}.IGH.fq
-samtools fastq ${sample_ID}.unmapped.bam >> ${sample_ID}.IGH.fq
 
 cd -


### PR DESCRIPTION
1. fix the redundant samtools fastq process in collect_IGH_from_grch38.sh
2. add the collect_IGH_from_chm13.sh for different reference genome user.
