### PR TITLE
Update the ReAsm2 pipeline

### DIFF
--- a/IGLoo/scripts/analyze_pacbio_refs.py
+++ b/IGLoo/scripts/analyze_pacbio_refs.py
@@ -154,7 +154,12 @@ def check_recomb_pair(pair_0, pair_1, list_gene_position, list_gene_name):
         elif gene_1[3] == "V" and abs(min_dist_1) < 300:
             return True, gene_0, gene_1, min_dist_0, min_dist_1
     elif abs(min_dist_0 - min_dist_1) < 50:
+        #print(True, gene_0, gene_1, min_dist_0, min_dist_1)
+        # accommodate the case of SV deletion between IGHD2-8 and IGHD2-2
+        if gene_0 == "IGHD2-8" and gene_1 == "IGHD2-2":
+            return False, gene_0, gene_1, min_dist_0, min_dist_1
         return True, gene_0, gene_1, min_dist_0, min_dist_1
+    #print(False, gene_0, gene_1, min_dist_0, min_dist_1)
     return False, gene_0, gene_1, min_dist_0, min_dist_1
 
 

--- a/IGLoo/scripts/force_polish.py
+++ b/IGLoo/scripts/force_polish.py
@@ -1,0 +1,121 @@
+#Force polish a genome with samtools mpileup
+
+import argparse
+from collections import defaultdict
+
+def parse_bases(bases: str) -> dict:
+    """Parse mpileup base string and return counts of each base type.
+    
+    Args:
+        bases: String from mpileup containing base information
+              '.' or ',' = match to reference
+              'ACGT' or 'acgt' = mismatch base
+              '+Nx' = insertion of N bases
+              '-Nx' = deletion of N bases (preceded by . or ,)
+              
+    Returns:
+        Dictionary with counts of each base type, including deletions
+    """
+    parsed_bases = defaultdict(int)
+    i = 0
+    while i < len(bases):
+        # Skip start/end of read markers
+        if bases[i] == '^' and i + 1 < len(bases):
+            i += 2  # Skip quality score after ^
+            continue
+        if bases[i] == '$':
+            i += 1
+            continue
+            
+        # Handle deletions (must check for preceding . or ,)
+        if i + 1 < len(bases) and bases[i] in '.,' and bases[i+1] == '-':
+            i += 2  # Skip the . and -
+            # Get length of deletion
+            del_len = 0
+            while i < len(bases) and bases[i].isdigit():
+                del_len = del_len * 10 + int(bases[i])
+                i += 1
+            # Get the deleted sequence
+            del_seq = bases[i:i+del_len]
+            parsed_bases[f'-{del_seq.upper()}'] += 1
+            i += del_len
+            continue
+            
+        # Handle insertions
+        if bases[i] == '+':
+            i += 1
+            # Get length of insertion
+            ins_len = 0
+            while i < len(bases) and bases[i].isdigit():
+                ins_len = ins_len * 10 + int(bases[i])
+                i += 1
+            # Get the inserted sequence
+            ins_seq = bases[i:i+ins_len]
+            parsed_bases[f'+{ins_seq.upper()}'] += 1
+            i += ins_len
+            continue
+            
+        # Count reference matches
+        if bases[i] in ',.':
+            parsed_bases['ref'] += 1
+            
+        # Count alternative bases
+        elif bases[i].upper() in 'ACGT':
+            parsed_bases[bases[i].upper()] += 1
+            
+        i += 1
+        
+    return parsed_bases
+
+def read_mpileup(mpileup_file):
+    dict_change = defaultdict(list)
+    with open(mpileup_file, "r") as f:
+        for line in f:
+            fields = line.strip().split("\t")
+            chrom, pos, ref, depth, bases = fields[0], int(fields[1]), fields[2], int(fields[3]), fields[4]
+            # if over 0.8 of the depth is one specific alt base, call it
+            parsed_bases = parse_bases(bases)
+            for base, count in parsed_bases.items():
+                if base == 'ref':
+                    continue
+                if count / depth > 0.8:
+                    dict_change[chrom].append((pos, base))
+                    #print(f"{chrom}:{pos} {ref}->{base}")
+    return dict_change
+
+def force_polish(original_seq, list_change):
+    for pos, base in list_change[::-1]:
+        if original_seq[pos-1] == 'N':
+            continue
+        if base.startswith('-'):
+            original_seq = original_seq[:pos] + original_seq[pos+len(base)-1:]
+        elif base.startswith('+'):
+            original_seq = original_seq[:pos] + base[1:] + original_seq[pos:]
+        else:
+            original_seq = original_seq[:pos-1] + base + original_seq[pos:]
+    return original_seq
+
+def output_polish(genome_file, dict_change, out_file):
+    with open(genome_file, "r") as f, open(out_file, "w") as out:
+        for line in f:
+            if line.startswith(">"):
+                out.write(line)
+                chrom = line.strip().split(" ")[0][1:]
+            else:
+                polished_seq = force_polish(line.strip(), dict_change[chrom])
+                out.write(polished_seq + "\n")
+
+
+def main(arguments=None):
+    parser = argparse.ArgumentParser(description="Force polish a genome with samtools mpileup")
+    parser.add_argument("--genome", type=str, help="Path to the genome fasta file")
+    parser.add_argument("--mpileup", type=str, help="Path to the mpileup file")
+    parser.add_argument("--out", type=str, help="Path to the output file")
+    args = parser.parse_args(arguments)
+
+    dict_change = read_mpileup(args.mpileup)
+    output_polish(args.genome, dict_change, args.out)
+
+if __name__ == "__main__":
+    main()
+

--- a/IGLoo/scripts/mask_case_n_depth.py
+++ b/IGLoo/scripts/mask_case_n_depth.py
@@ -1,0 +1,133 @@
+import argparse
+import re
+
+
+def read_fasta(fn_fasta):
+    dict_read = {}
+    name = ""
+    seq  = ""
+    with open(fn_fasta) as f:
+        for line in f:
+            if line[0] == '>':
+                if name != "":
+                    dict_read[name] = seq
+                name = line[1:].strip()
+                seq = ""
+            else:
+                seq += line.strip()
+    dict_read[name] = seq
+    return dict_read
+
+
+def read_bed(fn_bed):
+    dict_region = {}
+    f = open(fn_bed)
+    for line in f:
+        fields = line.strip().split()
+        if dict_region.get(fields[0]):
+            dict_region[fields[0]].append(fields[1:])
+        else:
+            dict_region[fields[0]] = [fields[1:]]
+    f.close()
+    return dict_region
+
+
+def find_overlap(dict_rd, dict_up):
+    dict_crop_region = {}
+    for contig in sorted(dict_rd.keys()):
+        dict_crop_region[contig] = []
+        list_up_region = []
+        for bg, ed, length in dict_up[contig]:
+            if int(length) > 100:
+                list_up_region.append((int(bg), int(ed)))
+        list_rd_region = [(int(ele[0]), int(ele[1])) for ele in dict_rd[contig]]
+        for rd_bg, rd_ed in list_rd_region:
+            for up_bg, up_ed in list_up_region:
+                if (rd_bg <= up_bg and rd_ed >= up_bg) or (rd_bg <= up_ed and rd_ed >= up_ed): # include the upperCase region
+                    dict_crop_region[contig].append((rd_bg, rd_ed))
+                    break
+    print(dict_crop_region)
+    return dict_crop_region
+
+
+def mask_seq(regions, sequence):
+    old_bg = 0
+    for region in regions:
+        bg, ed, _ = region
+        bg = int(bg) -1
+        sequence = sequence[:old_bg] + 'N'*(bg-old_bg) + sequence[bg:]
+        #print(bg-old_bg)
+        old_bg = int(ed) -1
+    return sequence
+
+
+
+def output_fasta(dict_rd, dict_fasta, fo_fasta, dict_legit):
+    contig = "chr14"
+    fo = open(fo_fasta, "w")
+    hap_regions  = dict_rd[contig]
+    hap_sequence = dict_fasta[contig]
+    masked_sequence = mask_seq(hap_regions, hap_sequence)
+
+    for idy, region in enumerate(dict_legit[contig]):
+        bg, ed = region
+        fo.write(">IGH_masked_"+str(idy+1)+"\n")
+        #fo.write(">chr14\n")
+        fo.write(masked_sequence[bg:ed] + "\n")
+    fo.close()
+
+
+def check_Ns(dict_fasta, dict_up):
+    dict_legit = {}
+    contig = "chr14"
+    target_seq = dict_fasta[contig]
+    target_up  = dict_up[contig]
+    dict_legit[contig] = []
+
+    segments = re.split('N+', target_seq)
+    if len(segments) == 1:
+        dict_legit[contig].append((0, len(target_seq)))
+    else:
+        for segment in segments:
+            seg_start = target_seq.find(segment)
+            seg_stop  = seg_start + len(segment)
+            for up_info in target_up:
+                up_bg, up_ed, up_len = up_info
+                if int(up_len) < 1000:
+                    continue
+                up_bg = int(up_bg) - 1
+                up_ed = int(up_ed) - 1
+                if (up_bg >= seg_start and up_bg <= seg_stop) or (up_ed >= seg_start and up_ed <= seg_stop):
+                    dict_legit[contig].append((seg_start, seg_stop))
+                    break
+        print(dict_legit)
+    return dict_legit
+
+
+
+
+
+def main(arguments=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-rd',  '--read_depth_bed', required=True, help='the read depth log of the realignment to the region.')
+    parser.add_argument('-up',  '--upperCase_bed', required=True, help='the upper case bed report from the reassembly')
+    parser.add_argument('-fa',  '--reassembly_fa', required=True, help='the reassembled fasta')
+    parser.add_argument('-out', '--output_fa',  help='the output fasta of the two haplotypes.')
+    args = parser.parse_args(arguments)
+
+    rd_bed = args.read_depth_bed
+    up_bed = args.upperCase_bed
+    fn_fasta = args.reassembly_fa
+    fo_fasta = args.output_fa
+
+    dict_fasta = read_fasta(fn_fasta)
+    dict_rd = read_bed(rd_bed)
+    dict_up = read_bed(up_bed)
+
+    dict_legit = check_Ns(dict_fasta, dict_up)
+    #dict_legit = {'chr14':[(0, len(dict_fasta['chr14']))]}
+    output_fasta(dict_rd, dict_fasta, fo_fasta, dict_legit)
+
+if __name__ == "__main__":
+    main()
+

--- a/IGLoo/scripts/split_read_from_yak.py
+++ b/IGLoo/scripts/split_read_from_yak.py
@@ -1,0 +1,54 @@
+import argparse
+
+def parse_yak(yak_file):
+    dict_yak = {}
+    with open(yak_file, "r") as f:
+        for line in f:
+            fields = line.strip().split()
+            dict_yak[fields[0]] = fields[1]
+    return dict_yak
+
+def parse_fasta(fasta_file, dict_yak, output):
+    f1 = open(output + '.H1.fasta', 'w')
+    f2 = open(output + '.H2.fasta', 'w')
+    with open(fasta_file, "r") as f:
+        flag_f1 = False
+        flag_f2 = False
+        for line in f:
+            if line.startswith(">"):
+                header = line.strip().split()[0][1:]
+                if dict_yak[header] == 'p':
+                    flag_f1 = True
+                    flag_f2 = False
+                    f1.write(line)
+                elif dict_yak[header] == 'm':
+                    flag_f1 = False
+                    flag_f2 = True
+                    f2.write(line)
+                else:
+                    flag_f1 = True
+                    flag_f2 = True
+                    f1.write(line)
+                    f2.write(line)
+            else:
+                if flag_f1:
+                    f1.write(line)
+                if flag_f2:
+                    f2.write(line)
+    f1.close()
+    f2.close()
+
+def main(arguments=None):
+    parser = argparse.ArgumentParser(description="Split read from yak")
+    parser.add_argument("--input_fasta", type=str, help="Input fasta file")
+    parser.add_argument("--input_yak", type=str, help="Input yak file")
+    parser.add_argument("--output", type=str, help="Output header of the H1 and H2 read files")
+    args = parser.parse_args(arguments)
+
+    dict_yak = parse_yak(args.input_yak)
+    parse_fasta(args.input_fasta, dict_yak, args.output)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-_Updated: Nov 19, 2024_
+_Updated: Dec 12, 2024_
 # IGLoo
 Analyzing the Immunoglobulin (IG) HiFi read data and assemblies derived from Lymphoblastoid cell lines (LCLs).
 
@@ -12,6 +12,12 @@ Analyzing the Immunoglobulin (IG) HiFi read data and assemblies derived from Lym
 - gAIRR-suite=v0.2.0
 - MaSuRCA=v4.1.0
 - JASPER=v1.0.2
+### Python packages
+- numpy
+- pysam
+- pandas
+- matplotlib
+- seaborn
 
 
 ## Usage
@@ -63,10 +69,11 @@ $ python3 IGLoo/IGLoo_read.py -id HG005 \
 ```
 The ```HG005.hprc.IGH.bam``` can be collected from a whole genome sequence alignment file with the following shell command:
 ```
-bash IGLoo/scripts/fetch_IGH_from_grch38.sh HG005 ./HG005_aligned_GRCh38_winnowmap.sorted.bam ./example/
+bash IGLoo/scripts/collect_IGH_from_grch38.sh HG005 ./HG005_aligned_GRCh38_winnowmap.sorted.bam ./example/
 ```
-The final results will be generated in
-```example/read_out/pc_report/```, including ```HG005.split.rpt```, which summarizes overall recombination events and their frequencies (read counts);  ```HG005.split.detail.rpt```, which lists each event alongside its corresponding read name; and ```HG005.pie_chart.pdf```, which shows a pie chart of all recombination events.
+```IGLoo/scripts/collect_IGH_from_grch38.sh``` and ```IGLoo/scripts/collect_IGH_from_chm13.sh``` are the utility scripts that can subset the full WGS alignments to only the IGH related alignments.
+
+The final results will be generated in ```example/read_out/pc_report/```, including ```HG005.split.rpt```, which summarizes overall recombination events and their frequencies (read counts);  ```HG005.split.detail.rpt```, which lists each event alongside its corresponding read name; and ```HG005.pie_chart.pdf```, which shows a pie chart of all recombination events.
 
 
 ### Running the ```IGLoo --ReAsm```
@@ -78,7 +85,7 @@ python3 IGLoo/IGLoo_ReAsm.py -rd example/ReAsm_out/ -id HG005 \
 
 export PYTHONPATH=/home/user/lib/python3.9
 python3 IGLoo/IGLoo_ReAsm2.py -rd example/ReAsm_out/ -id HG005 \
-                              -fa example/read_out2/processed_fasta/HG005.split.enrich.fa
+                              -fa example/read_out2/processed_fasta/HG005.split.fa
 ```
 
 Note that $PYTHONPATH needs to be specified to run JASPER and Jellyfish.


### PR DESCRIPTION
1. use yak triobin to separate reads from the two haplotypes.
2. polish the assembly without using enriched read file.  Enriched reads are only used in de novo assembly process.