### PR TITLE
Update the subset utility scripts

### DIFF
--- a/IGLoo/scripts/collect_IGH_from_chm13.sh
+++ b/IGLoo/scripts/collect_IGH_from_chm13.sh
@@ -1,18 +1,32 @@
-# usage: bash collect_IGH_from_chm13.sh sample_ID input_bam output_path
+# usage: bash collect_IGH_from_chm13.sh sample_ID input_bam output_path [--unmap]
 
 IGH_locus="chr14:99739969-101161492"
 sample_ID=$1
 input_bam=$2
 output_path=$3
+flag_unmap=$4
+
+include_unmapped=false
+
+# Check for --unmap option
+if [[ "$flag_unmap" == "--unmap" ]]; then
+    include_unmapped=true
+fi
 
 mkdir -p ${output_path}
 samtools view -h ${input_bam} ${IGH_locus}     -o ${output_path}/${sample_ID}.IGH_chr14.bam
-samtools view -h ${input_bam} '*'              -o ${output_path}/${sample_ID}.unmapped.bam
+if ${include_unmapped}; then
+    samtools view -h ${input_bam} '*'          -o ${output_path}/${sample_ID}.unmapped.bam
+fi
 
 cd ${output_path}
-samtools merge ${sample_ID}.IGH.bam \
-               ${sample_ID}.IGH_chr14.bam \
-               ${sample_ID}.unmapped.bam
+if ${include_unmapped}; then
+    samtools merge ${sample_ID}.IGH.bam \
+                   ${sample_ID}.IGH_chr14.bam \
+                   ${sample_ID}.unmapped.bam
+else
+    mv ${sample_ID}.IGH_chr14.bam ${sample_ID}.IGH.bam
+fi
 samtools fastq ${sample_ID}.IGH.bam      >  ${sample_ID}.IGH.fq
 
 cd -

--- a/IGLoo/scripts/collect_IGH_from_grch38.sh
+++ b/IGLoo/scripts/collect_IGH_from_grch38.sh
@@ -1,21 +1,37 @@
-# usage: bash collect_IGH_from_grch38.sh sample_ID input_bam output_path
+# usage: bash collect_IGH_from_grch38.sh sample_ID input_bam output_path [--unmap]
 
 IGH_locus="chr14:105486937-106979845"
 IGH_alt_locus="chr14_KI270726v1_random:0-43739"
 sample_ID=$1
 input_bam=$2
 output_path=$3
+flag_unmap=$4
+
+include_unmapped=false
+
+# Check for --unmap option
+if [[ "$flag_unmap" == "--unmap" ]]; then
+    include_unmapped=true
+fi
 
 mkdir -p ${output_path}
 samtools view -h ${input_bam} ${IGH_locus}     -o ${output_path}/${sample_ID}.IGH_chr14.bam
 samtools view -h ${input_bam} ${IGH_alt_locus} -o ${output_path}/${sample_ID}.IGH_alt.bam
-samtools view -h ${input_bam} '*'              -o ${output_path}/${sample_ID}.unmapped.bam
+if ${include_unmapped}; then
+    samtools view -h ${input_bam} '*'          -o ${output_path}/${sample_ID}.unmapped.bam
+fi
 
 cd ${output_path}
-samtools merge ${sample_ID}.IGH.bam \
-               ${sample_ID}.IGH_chr14.bam \
-               ${sample_ID}.IGH_alt.bam \
-               ${sample_ID}.unmapped.bam
+if ${include_unmapped}; then
+    samtools merge ${sample_ID}.IGH.bam \
+                   ${sample_ID}.IGH_chr14.bam \
+                   ${sample_ID}.IGH_alt.bam \
+                   ${sample_ID}.unmapped.bam
+else
+    samtools merge ${sample_ID}.IGH.bam \
+                   ${sample_ID}.IGH_chr14.bam \
+                   ${sample_ID}.IGH_alt.bam
+fi
 samtools fastq ${sample_ID}.IGH.bam      >  ${sample_ID}.IGH.fq
 
 cd -


### PR DESCRIPTION
The collection scripts used to include all the unmapped reads.  Now the default option doesn't include the unmapped reads.  However, users can still use --unmap option in the end to include the unmapped reads.

Though based on my experience, unmapped reads almost never changed the result.